### PR TITLE
Fix: Improve container communication and health checks for frontend-backend-mongo setup

### DIFF
--- a/Backend/.env
+++ b/Backend/.env
@@ -1,8 +1,8 @@
-HOST=http://localhost
+HOST=http://backend 
 PORT=8080
 
 # MONGO_URL=mongodb://mongoCont:27017/jasmine
 # MONGO_URL=mongodb://localhost:27017/jasmine
-MONGO_URL=mongodb://localhost:27017/jasminegraph_mongodb
+MONGO_URL=mongodb://mongoCont:27017/jasminegraph_mongodb
 
 DEV_MODE=true

--- a/Backend/src/constants/constants.ts
+++ b/Backend/src/constants/constants.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 export const HTTP = {
   "200": 200,
-  "201": 201,	
+  "201": 201,
   "400": 400,
   "401": 401,
   "404": 404,
@@ -24,4 +24,5 @@ export const HTTP = {
 export const TIMEOUT = {
   hundred: 100,
   default: 5000,
+  retryDelayMs: 3000,
 }

--- a/Backend/src/databaseConnection.ts
+++ b/Backend/src/databaseConnection.ts
@@ -13,6 +13,7 @@ limitations under the License.
 
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import { TIMEOUT } from './constants/constants';
 
 mongoose.Promise = global.Promise;
 dotenv.config();
@@ -30,7 +31,7 @@ const connectToDatabase = async () => {
       return;
     } catch (error) {
       console.log(`MongoDB connection failed (attempt ${retries + 1}). Retrying...`);
-      await new Promise(res => setTimeout(res, 3000)); // wait 3 sec
+      await new Promise(res => setTimeout(res, TIMEOUT.retryDelayMs));
       retries++;
     }
   }

--- a/Backend/src/databaseConnection.ts
+++ b/Backend/src/databaseConnection.ts
@@ -19,8 +19,23 @@ dotenv.config();
 
 const { MONGO_URL } = process.env;
 
-const connectToDatabase = async (): Promise<void> => {
-  await mongoose.connect(MONGO_URL ? MONGO_URL : 'mongodb://localhost:27017/jasmine')
- };
+const connectToDatabase = async () => {
+  const maxRetries = 10;
+  let retries = 0;
+
+  while (retries < maxRetries) {
+    try {
+      await mongoose.connect(MONGO_URL ? MONGO_URL : 'mongodb://mongoCont:27017/jasmine');
+      console.log('MongoDB connected');
+      return;
+    } catch (error) {
+      console.log(`MongoDB connection failed (attempt ${retries + 1}). Retrying...`);
+      await new Promise(res => setTimeout(res, 3000)); // wait 3 sec
+      retries++;
+    }
+  }
+
+  throw new Error("MongoDB connection failed after several retries");
+};
 
 export { connectToDatabase };

--- a/Backend/src/index.ts
+++ b/Backend/src/index.ts
@@ -14,6 +14,7 @@ limitations under the License.
 import express from 'express';
 import dotenv from 'dotenv';
 import http from 'http';
+import mongoose from 'mongoose';
 
 import { connectToDatabase } from './databaseConnection';
 import { userRoute } from './routes/user.routes';
@@ -59,7 +60,7 @@ app.get('/ping', (req, res) => {
 app.get('/health', async (req, res) => {
   try {
     // Check DB connection state using mongoose
-    const dbState = require('mongoose').connection.readyState;
+    const dbState = mongoose.connection.readyState;
     // 1 = connected, 2 = connecting, 0 = disconnected, 3 = disconnecting
     if (dbState === 1) {
       return res.status(200).json({ status: 'ok', db: 'connected' });
@@ -71,6 +72,7 @@ app.get('/health', async (req, res) => {
   }
 });
 
+// Bind to '0.0.0.0' to make the service accessible from all network interfaces.
 server.listen(PORT, '0.0.0.0', async () => {
   await connectToDatabase();
 

--- a/Frontend/.env.local
+++ b/Frontend/.env.local
@@ -1,2 +1,3 @@
-BACKEND='http://localhost:8080'
-
+# URL to backend service inside Docker network
+# Use service name 'backend' so Docker DNS resolves it correctly
+BACKEND='http://backend:8080'

--- a/Frontend/next.config.mjs
+++ b/Frontend/next.config.mjs
@@ -5,7 +5,7 @@ const nextConfig = {
     return [
       {
         source: "/backend/:path*",
-        destination: `http://localhost:8080/:path*`,
+        destination: `http://backend:8080/:path*`,
       },
     ];
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.9'
 services:
   # Frontend Service
   frontend:
@@ -8,10 +8,14 @@ services:
     image: jasminegraph-frontend:latest
     ports:
       - "3000:3000"
-    network_mode: host # Use host network mode
     environment:
       - BACKEND=http://backend:8080 # Pointing to the backend service
       - NEXT_PUBLIC_API_URL=http://backend:8080 # Pointing to the backend service
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   # Backend Service
   backend:
@@ -21,33 +25,46 @@ services:
     image: jasminegraph-backend:latest
     ports:
       - "8080:8080"
-    network_mode: host # Use host network mode
     depends_on:
-      - mongoCont
+      mongoCont:
+        condition: service_healthy
     volumes:
       - /var/tmp/jasminegraph-ui-backend:/app/caches
     environment:
-      - MONGO_URL=mongodb://localhost:27017/jasminegraph # Update to use localhost since mongoCont is on host network
+      - MONGO_URL=mongodb://mongoCont:27017/jasminegraph  
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
 
   # MongoDB Service
   mongoCont:
     image: mongo:latest
     ports:
       - "27017:27017"
-    network_mode: host
     volumes:
       - ./mongodb-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
   # Playwright Test Service
   playwright:
     build:
       context: ./tests
       dockerfile: Dockerfile
-    network_mode: host
     depends_on:
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
     environment:
-      - BASE_URL=http://localhost:3000
+      - BASE_URL=http://frontend:3000   
 
 volumes:
   mongodb-data:


### PR DESCRIPTION
### Summary

This PR addresses and resolves container communication issues between the **frontend**, **backend**, and **MongoDB** services in the JasmineGraph UI Docker setup. The update improves service discovery, adds health checks, and ensures reliable startup behavior using Docker’s default networking.


### Key Changes

**Docker Configuration**
  - Updated `docker-compose.yml`
  - Removed `network_mode: host`
  - Added `depends_on` with `condition: service_healthy` for startup dependency management
  - Defined health checks for:
    - `frontend`
    - `backend`
    - `mongoCont`
  - Updated `MONGO_URL` to use Docker DNS:  
    `mongodb://mongoCont:27017/jasminegraph`

**Environment Configuration**
  - Updated `Backend/.env` and `Frontend/.env.local` to reflect internal Docker service hostnames

**Code Improvements**
  - `Backend/src/databaseConnection.ts`: Added retry logic for MongoDB connection
  - `Backend/src/index.ts`: Added `/health` endpoint for service health monitoring
  - `Frontend/next.config.mjs`: Rewrites `/backend/*` requests to `http://backend:8080/*` for container-based API calls

**Console Output Updates:**
- Backend now logs:
  - `Application started on URL http://backend:8080` (for Docker)
  - `Access backend on your machine at http://localhost:8080`

**Server Binding Configuration:**
- Changed backend binding to `0.0.0.0`
  - Accessible from host: `http://localhost:8080`
  - Accessible from containers: `http://backend:8080`

### Testing
**Healthcheck Verification:**
- **MongoDB**: Verified with `mongosh` command
- **Backend**: `/health` endpoint returns correct status when DB is connected
- **Frontend**: Returns content successfully via `wget`

