### PR TITLE
Add Kubernetes deployment for JasmineGraph UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,49 @@ To stop the services, press `Ctrl+C` in the terminal which is occupied by `docke
 docker compose down
 ```
 
+# JasmineGraph UI Kubernetes Deployment
+
+Deploy the same stack (frontend, backend, postgres, keycloak) to a local Kubernetes cluster — works with either **minikube** or **k3s** (k3d too). Structured to match the deployment approach used by the [JasmineGraph server repo](https://github.com/miyurud/jasminegraph): plain `kubectl apply -f` manifests under `k8s/`, hostPath-backed volumes templated with `envsubst`, an `application: jasminegraph-ui` label for bulk cleanup, and a `start-k8s.sh clean` teardown command.
+
+## Prerequisites
+
+- Docker
+- `kubectl`
+- One of: [minikube](https://minikube.sigs.k8s.io/docs/start/), [k3s](https://docs.k3s.io/quick-start), or [k3d](https://k3d.io/)
+- Your cluster running, e.g. `minikube start` (or `k3s` installed as a service / `k3d cluster create`)
+
+## Deploy
+
+```bash
+./start-k8s.sh
+```
+
+The script auto-detects minikube vs. k3s/k3d, builds the frontend/backend images, loads them into the cluster (no external registry needed), applies the manifests in `k8s/`, waits for every deployment to become ready, and prints the URL to open.
+
+Optional flags (all have defaults):
+
+```bash
+./start-k8s.sh --CLUSTER_TYPE minikube \
+  --POSTGRES_DATA_PATH "$HOME/jasminegraph-ui-data/postgres" \
+  --BACKEND_CACHE_PATH "$HOME/jasminegraph-ui-data/backend-cache"
+```
+
+> **minikube note:** hostPath volumes resolve on the *node* (minikube's VM/container), not this machine — the script runs `minikube ssh` to create the data directories there automatically. On k3s/k3d the paths are created directly on the host.
+
+## Tear down
+
+```bash
+./start-k8s.sh clean
+```
+
+## Notes
+
+- Manifests live under `k8s/` — plain YAML, no kustomize, applied directly via `kubectl apply -f`.
+- The Postgres init SQL and Keycloak realm import are loaded into ConfigMaps at deploy time straight from `Backend/src/db-init/` and `Keycloak/jasminegraph-realm.json` — the same files `docker-compose.yml` uses — so there's nothing to keep in sync by hand.
+- Credentials in `k8s/secrets.yaml` are dev-only defaults matching `docker-compose.yml`; replace them before using this anywhere beyond a local cluster.
+- The Playwright test service isn't included — it's test-only tooling, not part of the running app.
+- This deploys into the `default` namespace, same as the JasmineGraph server repo — so both can run on the same local cluster side by side without conflicting (resource names differ). See that repo's `K3S_CLUSTER_SETUP_GUIDE.md` for running the graph server itself; the UI's backend connects to it by registering its `jasminegraph-master-service` host/port as a "cluster" in the UI, not through any shared config.
+
 ## Deployment Instructions
 
 JasmineGraph UI documentation: [documentation](https://github.com/jasminegraph/jasminegraph-ui/blob/feature/graph_visualization2/JasmineGraph-UI-Documentation.pdf)

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ Deploy the same stack (frontend, backend, postgres, keycloak) to a local Kuberne
 
 - Docker
 - `kubectl`
+- `envsubst` (GNU gettext; used to template `k8s/volumes.yaml`)
 - One of: [minikube](https://minikube.sigs.k8s.io/docs/start/), [k3s](https://docs.k3s.io/quick-start), or [k3d](https://k3d.io/)
-- Your cluster running, e.g. `minikube start` (or `k3s` installed as a service / `k3d cluster create`)
+- Your cluster running, e.g., `minikube start` (or `k3s` installed as a service / `k3d cluster create`)
 
 ## Deploy
 
@@ -149,7 +150,7 @@ Optional flags (all have defaults):
 - The Postgres init SQL and Keycloak realm import are loaded into ConfigMaps at deploy time straight from `Backend/src/db-init/` and `Keycloak/jasminegraph-realm.json` — the same files `docker-compose.yml` uses — so there's nothing to keep in sync by hand.
 - Credentials in `k8s/secrets.yaml` are dev-only defaults matching `docker-compose.yml`; replace them before using this anywhere beyond a local cluster.
 - The Playwright test service isn't included — it's test-only tooling, not part of the running app.
-- This deploys into the `default` namespace, same as the JasmineGraph server repo — so both can run on the same local cluster side by side without conflicting (resource names differ). See that repo's `K3S_CLUSTER_SETUP_GUIDE.md` for running the graph server itself; the UI's backend connects to it by registering its `jasminegraph-master-service` host/port as a "cluster" in the UI, not through any shared config.
+- This deploys into the `default` namespace, same as the JasmineGraph server repo — so both can run on the same local cluster side-by-side without conflicting (resource names differ). The UI's backend connects to the graph server by registering its `jasminegraph-master-service` host/port as a "cluster" in the UI, not through any shared config.
 
 ## Deployment Instructions
 
@@ -182,3 +183,4 @@ Contributions are welcome! Please follow these steps to contribute:
 ## Contact
 
 For any questions or issues, please open an issue on the GitHub repository or contact the maintainers.
+

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jasminegraph-ui-backend-deployment
+  labels:
+    application: jasminegraph-ui
+spec:
+  replicas: 1
+  # Recreate: backend-cache is ReadWriteOnce, same reasoning as postgres above.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      service: jasminegraph-ui
+      type: backend
+  template:
+    metadata:
+      labels:
+        service: jasminegraph-ui
+        type: backend
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - until nc -z postgres 5432; do echo waiting for postgres; sleep 2; done
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: jasminegraph-ui-backend-cache-claim
+      containers:
+        - name: backend
+          image: jasminegraph-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-postgres-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_URL
+              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@postgres:5432/$(POSTGRES_DB)
+            - name: HOST
+              value: http://backend
+            - name: PORT
+              value: "8080"
+          volumeMounts:
+            - name: cache
+              mountPath: /app/caches
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 750m
+              memory: 768Mi

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -84,3 +84,4 @@ spec:
             limits:
               cpu: 750m
               memory: 768Mi
+

--- a/k8s/backend-service.yaml
+++ b/k8s/backend-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Must be named exactly "backend" — Frontend/next.config.mjs rewrites
+  # /backend/:path* to http://backend:8080 over cluster DNS.
+  name: backend
+  labels:
+    application: jasminegraph-ui
+spec:
+  selector:
+    service: jasminegraph-ui
+    type: backend
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/k8s/backend-service.yaml
+++ b/k8s/backend-service.yaml
@@ -14,3 +14,4 @@ spec:
     - port: 8080
       targetPort: 8080
   type: ClusterIP
+

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jasminegraph-ui-frontend-deployment
+  labels:
+    application: jasminegraph-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: jasminegraph-ui
+      type: frontend
+  template:
+    metadata:
+      labels:
+        service: jasminegraph-ui
+        type: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: jasminegraph-frontend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: BACKEND
+              value: http://backend:8080
+            - name: NEXT_PUBLIC_API_URL
+              value: http://backend:8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/frontend-deployment.yaml
+++ b/k8s/frontend-deployment.yaml
@@ -50,3 +50,4 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jasminegraph-ui-frontend-service
+  labels:
+    application: jasminegraph-ui
+spec:
+  ports:
+    - port: 3000
+      name: "http"
+      nodePort: 30080
+  selector:
+    service: jasminegraph-ui
+    type: frontend
+  type: NodePort

--- a/k8s/frontend-service.yaml
+++ b/k8s/frontend-service.yaml
@@ -13,3 +13,4 @@ spec:
     service: jasminegraph-ui
     type: frontend
   type: NodePort
+

--- a/k8s/keycloak-deployment.yaml
+++ b/k8s/keycloak-deployment.yaml
@@ -102,3 +102,4 @@ spec:
             limits:
               cpu: 1
               memory: 1Gi
+

--- a/k8s/keycloak-deployment.yaml
+++ b/k8s/keycloak-deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jasminegraph-ui-keycloak-deployment
+  labels:
+    application: jasminegraph-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: jasminegraph-ui
+      type: keycloak
+  template:
+    metadata:
+      labels:
+        service: jasminegraph-ui
+        type: keycloak
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - until nc -z postgres 5432; do echo waiting for postgres; sleep 2; done
+      volumes:
+        - name: realm-config
+          configMap:
+            name: jasminegraph-ui-keycloak-realm
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.1.1
+          args: ["start-dev", "--import-realm"]
+          ports:
+            - containerPort: 8080
+          env:
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-keycloak-secret
+                  key: KC_BOOTSTRAP_ADMIN_USERNAME
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-keycloak-secret
+                  key: KC_BOOTSTRAP_ADMIN_PASSWORD
+            - name: KC_DB
+              value: postgres
+            - name: KC_DB_URL_HOST
+              value: postgres
+            - name: KC_DB_URL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-postgres-secret
+                  key: POSTGRES_DB
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-postgres-secret
+                  key: POSTGRES_USER
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: jasminegraph-ui-postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_IMPORT
+              value: /opt/keycloak/data/import/jasminegraph-realm.json
+            - name: KC_IMPORT_STRATEGY
+              value: OVERWRITE_EXISTING
+          volumeMounts:
+            - name: realm-config
+              mountPath: /opt/keycloak/data/import/jasminegraph-realm.json
+              subPath: jasminegraph-realm.json
+          # start-dev has no health endpoint enabled by default, so a plain
+          # TCP check is the reliable option. First boot runs Quarkus
+          # augmentation, which alone can take 2-3 minutes on a CPU-limited
+          # host, so startupProbe gates the other probes generously (up to
+          # 10 minutes) to avoid killing the container mid-boot; once it
+          # succeeds, the tighter liveness/readiness windows take over.
+          startupProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 15
+            failureThreshold: 8
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1
+              memory: 1Gi

--- a/k8s/keycloak-service.yaml
+++ b/k8s/keycloak-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Must be named exactly "keycloak" — Backend controllers/middleware call
+  # http://keycloak:8080 literally (see Backend/src/middleware/keycloak.middleware.ts,
+  # Backend/src/utils/keycloak-admin-token.ts, Backend/src/controllers/auth.controller.ts).
+  name: keycloak
+  labels:
+    application: jasminegraph-ui
+spec:
+  selector:
+    service: jasminegraph-ui
+    type: keycloak
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/k8s/keycloak-service.yaml
+++ b/k8s/keycloak-service.yaml
@@ -15,3 +15,4 @@ spec:
     - port: 8080
       targetPort: 8080
   type: ClusterIP
+

--- a/k8s/postgres-deployment.yaml
+++ b/k8s/postgres-deployment.yaml
@@ -67,3 +67,4 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+

--- a/k8s/postgres-deployment.yaml
+++ b/k8s/postgres-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jasminegraph-ui-postgres-deployment
+  labels:
+    application: jasminegraph-ui
+spec:
+  replicas: 1
+  # Recreate (not RollingUpdate): the claim below is ReadWriteOnce, so a
+  # rolling update that tries to start a new pod before killing the old one
+  # would get stuck Pending forever waiting to attach the volume a second time.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      service: jasminegraph-ui
+      type: postgres
+  template:
+    metadata:
+      labels:
+        service: jasminegraph-ui
+        type: postgres
+    spec:
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: jasminegraph-ui-postgres-data-claim
+        - name: db-init
+          configMap:
+            name: jasminegraph-ui-db-init
+      containers:
+        - name: postgres
+          image: postgres:17
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - secretRef:
+                name: jasminegraph-ui-postgres-secret
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+              # subPath avoids Postgres refusing to start because the mount
+              # root already contains a lost+found directory, which hostPath
+              # volumes commonly do.
+              subPath: pgdata
+            - name: db-init
+              mountPath: /docker-entrypoint-initdb.d
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/postgres-service.yaml
+++ b/k8s/postgres-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # Must be named exactly "postgres" — the backend and keycloak deployments
+  # connect to this hostname literally (see Backend/src/databaseConnection.ts
+  # and the docker-compose.yml this manifest replaces).
+  name: postgres
+  labels:
+    application: jasminegraph-ui
+spec:
+  selector:
+    service: jasminegraph-ui
+    type: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/k8s/postgres-service.yaml
+++ b/k8s/postgres-service.yaml
@@ -15,3 +15,4 @@ spec:
     - port: 5432
       targetPort: 5432
   type: ClusterIP
+

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -23,3 +23,4 @@ type: Opaque
 stringData:
   KC_BOOTSTRAP_ADMIN_USERNAME: admin
   KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,25 @@
+# Dev-only credentials, mirroring the values already hardcoded in docker-compose.yml.
+# Replace these before using this manifest anywhere but a local minikube/k3s cluster.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jasminegraph-ui-postgres-secret
+  labels:
+    application: jasminegraph-ui
+type: Opaque
+stringData:
+  POSTGRES_DB: jasminegraphdb
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: admin_password
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jasminegraph-ui-keycloak-secret
+  labels:
+    application: jasminegraph-ui
+type: Opaque
+stringData:
+  KC_BOOTSTRAP_ADMIN_USERNAME: admin
+  KC_BOOTSTRAP_ADMIN_PASSWORD: admin

--- a/k8s/volumes.yaml
+++ b/k8s/volumes.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jasminegraph-ui-postgres-data
+  labels:
+    application: jasminegraph-ui
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  claimRef:
+    namespace: default
+    name: jasminegraph-ui-postgres-data-claim
+  hostPath:
+    path: "${postgres_data_path}"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jasminegraph-ui-postgres-data-claim
+  labels:
+    application: jasminegraph-ui
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jasminegraph-ui-backend-cache
+  labels:
+    application: jasminegraph-ui
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  claimRef:
+    namespace: default
+    name: jasminegraph-ui-backend-cache-claim
+  hostPath:
+    path: "${backend_cache_path}"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jasminegraph-ui-backend-cache-claim
+  labels:
+    application: jasminegraph-ui
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/volumes.yaml
+++ b/k8s/volumes.yaml
@@ -66,3 +66,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
+

--- a/start-k8s.sh
+++ b/start-k8s.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+#
+# Deploy JasmineGraph UI (frontend, backend, postgres, keycloak) to a local
+# Kubernetes cluster (minikube or k3s/k3d). Structured to match
+# ../jasminegraph/start-k8s.sh: plain `kubectl apply -f` manifests under
+# k8s/, hostPath-backed volumes templated with envsubst, an `application`
+# label for bulk cleanup, and a `clean` subcommand for teardown.
+#
+# Usage:
+#   ./start-k8s.sh clean
+#   ./start-k8s.sh [--CLUSTER_TYPE minikube|k3s|k3d] \
+#                  [--POSTGRES_DATA_PATH <path>] [--BACKEND_CACHE_PATH <path>]
+#
+# All flags are optional — omitted paths default under $HOME/jasminegraph-ui-data
+# and are created automatically; cluster type is auto-detected if omitted.
+
+set -e
+
+TIMEOUT_SECONDS=600
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$1" == "clean" ]; then
+    echo "Cleaning JasmineGraph UI resources..."
+    kubectl delete deployments -l application=jasminegraph-ui --ignore-not-found
+    kubectl delete services -l application=jasminegraph-ui --ignore-not-found
+    kubectl delete configmaps -l application=jasminegraph-ui --ignore-not-found
+    kubectl delete secrets -l application=jasminegraph-ui --ignore-not-found
+    kubectl delete pvc -l application=jasminegraph-ui --ignore-not-found
+    kubectl delete pv -l application=jasminegraph-ui --ignore-not-found
+    exit 0
+fi
+
+CLUSTER_TYPE=${CLUSTER_TYPE}
+POSTGRES_DATA_PATH=${POSTGRES_DATA_PATH}
+BACKEND_CACHE_PATH=${BACKEND_CACHE_PATH}
+IMAGE_TAG=${IMAGE_TAG:-latest}
+
+while [ $# -gt 0 ]; do
+    if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare "$param"="$2"
+        echo "$1" "=" "$2"
+    fi
+    shift
+done
+
+detect_cluster() {
+    if command -v minikube >/dev/null 2>&1 && minikube status >/dev/null 2>&1; then
+        echo "minikube"
+    elif kubectl config current-context 2>/dev/null | grep -qi "k3d-"; then
+        echo "k3d"
+    elif command -v k3s >/dev/null 2>&1; then
+        echo "k3s"
+    else
+        echo "unknown"
+    fi
+}
+
+if [ -z "$CLUSTER_TYPE" ]; then
+    CLUSTER_TYPE="$(detect_cluster)"
+fi
+
+if [ "$CLUSTER_TYPE" == "unknown" ]; then
+    echo "Could not auto-detect minikube, k3s, or k3d."
+    echo "Make sure your cluster is running, or pass the type explicitly:"
+    echo "  ./start-k8s.sh --CLUSTER_TYPE minikube"
+    echo "  ./start-k8s.sh --CLUSTER_TYPE k3s"
+    echo "  ./start-k8s.sh --CLUSTER_TYPE k3d"
+    exit 1
+fi
+
+echo "Target cluster: $CLUSTER_TYPE"
+
+if [ -z "$POSTGRES_DATA_PATH" ]; then
+    POSTGRES_DATA_PATH="$HOME/jasminegraph-ui-data/postgres"
+fi
+
+if [ -z "$BACKEND_CACHE_PATH" ]; then
+    BACKEND_CACHE_PATH="$HOME/jasminegraph-ui-data/backend-cache"
+fi
+
+# minikube's kubelet runs inside its own VM/container, so hostPath refers to
+# a path on the minikube node, not this machine. Create it there instead.
+if [ "$CLUSTER_TYPE" == "minikube" ]; then
+    minikube ssh -- "mkdir -p '$POSTGRES_DATA_PATH' '$BACKEND_CACHE_PATH'"
+else
+    mkdir -p "$POSTGRES_DATA_PATH" "$BACKEND_CACHE_PATH"
+fi
+
+FRONTEND_IMAGE="jasminegraph-frontend:${IMAGE_TAG}"
+BACKEND_IMAGE="jasminegraph-backend:${IMAGE_TAG}"
+
+echo "Building frontend image ($FRONTEND_IMAGE)..."
+docker build -t "$FRONTEND_IMAGE" "$SCRIPT_DIR/Frontend"
+
+echo "Building backend image ($BACKEND_IMAGE)..."
+docker build -t "$BACKEND_IMAGE" "$SCRIPT_DIR/Backend"
+
+echo "Loading images into $CLUSTER_TYPE..."
+case "$CLUSTER_TYPE" in
+    minikube)
+        minikube image load "$FRONTEND_IMAGE"
+        minikube image load "$BACKEND_IMAGE"
+        ;;
+    k3d)
+        k3d image import "$FRONTEND_IMAGE" "$BACKEND_IMAGE"
+        ;;
+    k3s)
+        if sudo systemctl cat k3s 2>/dev/null | grep -q -- '--docker'; then
+            # k3s is configured to use the host Docker daemon as its
+            # container runtime (--docker flag), so images built with
+            # `docker build` are already visible to it — nothing to import.
+            :
+        else
+            # k3s's embedded containerd is a separate runtime from the host
+            # Docker daemon, so locally-built images have to be imported by hand.
+            docker save "$FRONTEND_IMAGE" | sudo k3s ctr images import -
+            docker save "$BACKEND_IMAGE" | sudo k3s ctr images import -
+        fi
+        ;;
+esac
+
+echo "Applying secrets..."
+kubectl apply -f "$SCRIPT_DIR/k8s/secrets.yaml"
+
+echo "Applying volumes..."
+postgres_data_path="${POSTGRES_DATA_PATH}" \
+    backend_cache_path="${BACKEND_CACHE_PATH}" \
+    envsubst <"$SCRIPT_DIR/k8s/volumes.yaml" | kubectl apply -f -
+
+echo "Generating config maps from Backend/src/db-init and Keycloak/jasminegraph-realm.json..."
+kubectl create configmap jasminegraph-ui-db-init \
+    --from-file="$SCRIPT_DIR/Backend/src/db-init" \
+    --dry-run=client -o yaml | kubectl label -f - --local -o yaml application=jasminegraph-ui | kubectl apply -f -
+
+kubectl create configmap jasminegraph-ui-keycloak-realm \
+    --from-file="$SCRIPT_DIR/Keycloak/jasminegraph-realm.json" \
+    --dry-run=client -o yaml | kubectl label -f - --local -o yaml application=jasminegraph-ui | kubectl apply -f -
+
+echo "Applying postgres..."
+kubectl apply -f "$SCRIPT_DIR/k8s/postgres-deployment.yaml" -f "$SCRIPT_DIR/k8s/postgres-service.yaml"
+kubectl rollout status deployment/jasminegraph-ui-postgres-deployment --timeout="${TIMEOUT_SECONDS}s"
+
+echo "Applying backend..."
+kubectl apply -f "$SCRIPT_DIR/k8s/backend-deployment.yaml" -f "$SCRIPT_DIR/k8s/backend-service.yaml"
+kubectl rollout status deployment/jasminegraph-ui-backend-deployment --timeout="${TIMEOUT_SECONDS}s"
+
+echo "Applying keycloak..."
+kubectl apply -f "$SCRIPT_DIR/k8s/keycloak-deployment.yaml" -f "$SCRIPT_DIR/k8s/keycloak-service.yaml"
+kubectl rollout status deployment/jasminegraph-ui-keycloak-deployment --timeout="${TIMEOUT_SECONDS}s"
+
+echo "Applying frontend..."
+kubectl apply -f "$SCRIPT_DIR/k8s/frontend-deployment.yaml" -f "$SCRIPT_DIR/k8s/frontend-service.yaml"
+kubectl rollout status deployment/jasminegraph-ui-frontend-deployment --timeout="${TIMEOUT_SECONDS}s"
+
+echo ""
+echo "All JasmineGraph UI pods are running."
+case "$CLUSTER_TYPE" in
+    minikube)
+        minikube service jasminegraph-ui-frontend-service --url
+        ;;
+    *)
+        NODE_IP="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+        echo "Connect to JasmineGraph UI at http://$NODE_IP:30080"
+        ;;
+esac

--- a/start-k8s.sh
+++ b/start-k8s.sh
@@ -36,12 +36,24 @@ BACKEND_CACHE_PATH=${BACKEND_CACHE_PATH}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 
 while [ $# -gt 0 ]; do
-    if [[ $1 == *"--"* ]]; then
-        param="${1/--/}"
-        declare "$param"="$2"
-        echo "$1" "=" "$2"
-    fi
-    shift
+    case "$1" in
+        --CLUSTER_TYPE)
+            CLUSTER_TYPE="$2"
+            shift 2
+            ;;
+        --POSTGRES_DATA_PATH)
+            POSTGRES_DATA_PATH="$2"
+            shift 2
+            ;;
+        --BACKEND_CACHE_PATH)
+            BACKEND_CACHE_PATH="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+    esac
 done
 
 detect_cluster() {
@@ -106,7 +118,7 @@ case "$CLUSTER_TYPE" in
         k3d image import "$FRONTEND_IMAGE" "$BACKEND_IMAGE"
         ;;
     k3s)
-        if sudo systemctl cat k3s 2>/dev/null | grep -q -- '--docker'; then
+        if sudo -n systemctl cat k3s 2>/dev/null | grep -q -- '--docker'; then
             # k3s is configured to use the host Docker daemon as its
             # container runtime (--docker flag), so images built with
             # `docker build` are already visible to it — nothing to import.
@@ -143,6 +155,7 @@ kubectl rollout status deployment/jasminegraph-ui-postgres-deployment --timeout=
 
 echo "Applying backend..."
 kubectl apply -f "$SCRIPT_DIR/k8s/backend-deployment.yaml" -f "$SCRIPT_DIR/k8s/backend-service.yaml"
+kubectl set image deployment/jasminegraph-ui-backend-deployment backend="$BACKEND_IMAGE"
 kubectl rollout status deployment/jasminegraph-ui-backend-deployment --timeout="${TIMEOUT_SECONDS}s"
 
 echo "Applying keycloak..."
@@ -151,6 +164,7 @@ kubectl rollout status deployment/jasminegraph-ui-keycloak-deployment --timeout=
 
 echo "Applying frontend..."
 kubectl apply -f "$SCRIPT_DIR/k8s/frontend-deployment.yaml" -f "$SCRIPT_DIR/k8s/frontend-service.yaml"
+kubectl set image deployment/jasminegraph-ui-frontend-deployment frontend="$FRONTEND_IMAGE"
 kubectl rollout status deployment/jasminegraph-ui-frontend-deployment --timeout="${TIMEOUT_SECONDS}s"
 
 echo ""
@@ -164,3 +178,4 @@ case "$CLUSTER_TYPE" in
         echo "Connect to JasmineGraph UI at http://$NODE_IP:30080"
         ;;
 esac
+


### PR DESCRIPTION
Deploy frontend, backend, postgres, and keycloak to a local minikube/k3s/k3d cluster via plain  manifests.Auto-detect cluster type and adapt image loading accordingly and Template hostPath volumes with envsubst so postgres and backend cache data survive pod restarts.